### PR TITLE
Add interactive voice call pipeline

### DIFF
--- a/llm/openai_handler.py
+++ b/llm/openai_handler.py
@@ -1,3 +1,25 @@
-def ask_openai(prompt):
-    # Aquí luego conectaremos con OpenAI API y devolveremos la respuesta
-    pass
+import openai
+from utils.config import OPENAI_API_KEY
+
+openai.api_key = OPENAI_API_KEY
+
+
+def ask_openai(prompt, chat_history=None, model="gpt-3.5-turbo"):
+    """Send a prompt to OpenAI and return the assistant's reply.
+
+    Parameters
+    ----------
+    prompt: str
+        Text to send as the latest user message.
+    chat_history: list, optional
+        Previous chat history formatted as a list of message dicts.
+    model: str, optional
+        OpenAI chat model to use.
+    """
+    messages = chat_history[:] if chat_history else []
+    messages.append({"role": "user", "content": prompt})
+
+    response = openai.ChatCompletion.create(model=model, messages=messages)
+    answer = response.choices[0].message["content"].strip()
+    messages.append({"role": "assistant", "content": answer})
+    return answer, messages

--- a/main.py
+++ b/main.py
@@ -1,0 +1,26 @@
+import signal
+
+from llm.openai_handler import ask_openai
+from stt.whisper_handler import listen_and_transcribe
+from tts.tts_handler import speak_text
+
+
+def run_call():
+    """Run a simple voice call loop until interrupted."""
+    conversation = []
+    print("Starting call. Press Ctrl+C to hang up.")
+    try:
+        while True:
+            user_text = listen_and_transcribe()
+            if not user_text:
+                continue
+            print(f"User: {user_text}")
+            response, conversation = ask_openai(user_text, conversation)
+            print(f"Assistant: {response}")
+            speak_text(response)
+    except KeyboardInterrupt:
+        print("\nCall ended.")
+
+
+if __name__ == "__main__":
+    run_call()

--- a/stt/whisper_handler.py
+++ b/stt/whisper_handler.py
@@ -1,0 +1,17 @@
+import numpy as np
+import sounddevice as sd
+from faster_whisper import WhisperModel
+from utils.config import WHISPER_MODEL_SIZE
+
+_model = WhisperModel(WHISPER_MODEL_SIZE)
+
+
+def listen_and_transcribe(duration=5, sample_rate=16000):
+    """Record audio from the microphone and return the transcribed text."""
+    print("Listening...")
+    recording = sd.rec(int(duration * sample_rate), samplerate=sample_rate, channels=1)
+    sd.wait()
+    audio = recording.flatten()
+    segments, _ = _model.transcribe(audio, language="es")
+    text = " ".join(segment.text for segment in segments)
+    return text.strip()

--- a/tts/tts_handler.py
+++ b/tts/tts_handler.py
@@ -1,3 +1,12 @@
+from TTS.api import TTS
+import sounddevice as sd
+from utils.config import TTS_MODEL_NAME
+
+_tts = TTS(TTS_MODEL_NAME)
+
+
 def speak_text(text):
-    # Aquí luego convertiremos texto en audio usando Coqui TTS
-    pass
+    """Speak the given text using Coqui TTS."""
+    waveform = _tts.tts(text)
+    sd.play(waveform, samplerate=_tts.synthesizer.output_sample_rate)
+    sd.wait()


### PR DESCRIPTION
## Summary
- implement OpenAI chat handling
- add microphone transcription with faster-whisper
- convert assistant responses to speech using Coqui TTS
- create a simple main loop to simulate a phone call

## Testing
- `pytest -q`
- `python -m py_compile llm/openai_handler.py stt/whisper_handler.py tts/tts_handler.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_684908c34c68832f89199248153b612b